### PR TITLE
Fix issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,4 +1,4 @@
-name: Main
+name: Enhancement
 description: Request an enhancement or feature. THIS IS NOT FOR BUG REPORTS
 title: "[Enhancement]: "
 body:


### PR DESCRIPTION
Due to the two issue template enhancement.yml and main.yml have the same "name" properties, both templates become broken and therefore it is not able to submit a new issue.
I simply changed the "name" properties of enhancement.yml to "Enhancment".