### PR TITLE
Fix broken text rendering after certain characters

### DIFF
--- a/src/main/java/com/ventooth/swansong/mixin/mixins/client/FastTextRender/FontRendererMixin.java
+++ b/src/main/java/com/ventooth/swansong/mixin/mixins/client/FastTextRender/FontRendererMixin.java
@@ -425,7 +425,7 @@ public abstract class FontRendererMixin implements FastFontRenderer {
             if (character > 0 && i != -1 && !this.unicodeFlag) {
                 return this.charWidth[i];
             } else if (this.glyphWidth[character] != 0) {
-                int j = this.glyphWidth[character] >>> 4;
+                int j = (this.glyphWidth[character] >>> 4) & 15;
                 int k = this.glyphWidth[character] & 15;
 
                 if (k > 7) {
@@ -503,7 +503,7 @@ public abstract class FontRendererMixin implements FastFontRenderer {
             return 0.0F;
         } else {
             int glyphTex = ch / 256;
-            float widthM = (float) (this.glyphWidth[ch] >>> 4);
+            float widthM = (float) ((this.glyphWidth[ch] >>> 4) & 15);
             float widthL = (float) (this.glyphWidth[ch] & 15);
             float kerning = widthL + 1;
             float u = (float) (ch % 16 * 16) + widthM;


### PR DESCRIPTION
This PR fixed a font rendering issue where texts after certain characters will get out of the game window and become invisible.
Vanilla MC 1.7.10 also has this kind of issue and this issue had been reported to Mojang as [MC-13046](https://bugs.mojang.com/browse/MC/issues/MC-13046), which has been fixed in MC 1.9. However, the FastTextRender module of SwanSong still uses the broken logic in vanilla 1.7.10, which results in the same behavior.
This PR fixed this by some AND calculations, like what Mojang has done in 1.9.